### PR TITLE
Apply multi-arch hints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Section: doc
 Depends: ${misc:Depends}
 Recommends: ${maven:DocDepends}, ${maven:DocOptionalDepends}
 Suggests: libsdes4j-java
+Multi-Arch: foreign
 Description: Documentation for sdes4j
  SDES (RFC4568) implementation for Java
  sdes4j is a small Java library to parse and generate


### PR DESCRIPTION
Apply hints suggested by the [multi-arch hinter](https://wiki.debian.org/MultiArch/Hints).

* libsdes4j-java-doc: Add Multi-Arch: foreign. This fixes: libsdes4j-java-doc could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

Note that in some cases, these multi-arch hints may trigger lintian warnings until the dependencies of the package support multi-arch. This is expected, see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/multiarch-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/multiarch-fixes/pkg/sdes4j/286a6dec-2108-4c94-a867-585dbafbf830.